### PR TITLE
Add strikethrough support

### DIFF
--- a/VGHtmlParser.xcodeproj/project.pbxproj
+++ b/VGHtmlParser.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		35F0DCCA2732D4BC00315968 /* VGHtmlPTagTransform.m in Sources */ = {isa = PBXBuildFile; fileRef = 35F0DCB92732D4BC00315968 /* VGHtmlPTagTransform.m */; };
 		35F0DCCB2732D4BC00315968 /* VGHtmlATagTransfom.m in Sources */ = {isa = PBXBuildFile; fileRef = 35F0DCBA2732D4BC00315968 /* VGHtmlATagTransfom.m */; };
 		35F0DCCC2732D4BC00315968 /* VGHtmlBrTagTransform.m in Sources */ = {isa = PBXBuildFile; fileRef = 35F0DCBB2732D4BC00315968 /* VGHtmlBrTagTransform.m */; };
+		80962DF62B6ADD51000861F1 /* HtmlSTagTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 80962DF42B6ADD51000861F1 /* HtmlSTagTransform.h */; };
+		80962DF72B6ADD51000861F1 /* HtmlSTagTransform.m in Sources */ = {isa = PBXBuildFile; fileRef = 80962DF52B6ADD51000861F1 /* HtmlSTagTransform.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,6 +60,8 @@
 		35F0DCB92732D4BC00315968 /* VGHtmlPTagTransform.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VGHtmlPTagTransform.m; sourceTree = "<group>"; };
 		35F0DCBA2732D4BC00315968 /* VGHtmlATagTransfom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VGHtmlATagTransfom.m; sourceTree = "<group>"; };
 		35F0DCBB2732D4BC00315968 /* VGHtmlBrTagTransform.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VGHtmlBrTagTransform.m; sourceTree = "<group>"; };
+		80962DF42B6ADD51000861F1 /* HtmlSTagTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HtmlSTagTransform.h; sourceTree = "<group>"; };
+		80962DF52B6ADD51000861F1 /* HtmlSTagTransform.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HtmlSTagTransform.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +161,8 @@
 		35F0DCAC2732D4BC00315968 /* VintedTransformers */ = {
 			isa = PBXGroup;
 			children = (
+				80962DF42B6ADD51000861F1 /* HtmlSTagTransform.h */,
+				80962DF52B6ADD51000861F1 /* HtmlSTagTransform.m */,
 				35F0DCAD2732D4BC00315968 /* HtmlLiTagTransform.h */,
 				35F0DCAE2732D4BC00315968 /* HtmlITagTransform.h */,
 				35F0DCAF2732D4BC00315968 /* HtmlBTagTransform.m */,
@@ -200,6 +206,7 @@
 				35F0DCC82732D4BC00315968 /* VGHtmlATagTransfom.h in Headers */,
 				359E208F256402DF006695C6 /* TFHpple.h in Headers */,
 				35F0DCC62732D4BC00315968 /* HtmlATagTransform.h in Headers */,
+				80962DF62B6ADD51000861F1 /* HtmlSTagTransform.h in Headers */,
 				359E208C256402DF006695C6 /* TFHppleElement.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -278,6 +285,7 @@
 				35F0DCBD2732D4BC00315968 /* VGHtmlParser.m in Sources */,
 				359E2091256402DF006695C6 /* XPathQuery.m in Sources */,
 				35F0DCCC2732D4BC00315968 /* VGHtmlBrTagTransform.m in Sources */,
+				80962DF72B6ADD51000861F1 /* HtmlSTagTransform.m in Sources */,
 				359E2090256402DF006695C6 /* TFHppleElement.m in Sources */,
 				35F0DCC52732D4BC00315968 /* HtmlITagTransform.m in Sources */,
 				35F0DCC22732D4BC00315968 /* HtmlATagTransform.m in Sources */,

--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.h
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "VGHtmlTagTransform.h"
+
+@interface HtmlSTagTransform : NSObject<VGHtmlTagTransform>
+
+@end

--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
@@ -15,7 +15,7 @@
     }
     
     NSMutableAttributedString *result = [attrString mutableCopy];
-    NSDictionary *attributes = @{@"TextAttributeStrikethrough":@true};
+    NSDictionary *attributes = @{@"TextAttributeStrikethrough":@""};
     [result addAttributes:attributes range:NSMakeRange(0, result.length)];
     return [result copy];
 }

--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
@@ -1,0 +1,24 @@
+#import <UIKit/UIKit.h>
+#import "HtmlSTagTransform.h"
+
+@implementation HtmlSTagTransform
+
+- (NSString *)tagName
+{
+    return @"s";
+}
+
+- (NSAttributedString *)transformAttributedString:(NSAttributedString *)attrString element:(TFHppleElement *)element
+{
+    if (!attrString.length) {
+        return attrString;
+    }
+    
+    NSMutableAttributedString *result = [attrString mutableCopy];
+    NSDictionary *attributes = @{@"TextAttributeStrikethrough":@""};
+    [result addAttributes:attributes range:NSMakeRange(0, result.length)];
+    return [result copy];
+}
+
+@end
+

--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
@@ -15,7 +15,7 @@
     }
     
     NSMutableAttributedString *result = [attrString mutableCopy];
-    NSDictionary *attributes = @{@"TextAttributeStrikethrough":@""};
+    NSDictionary *attributes = @{@"TextAttributeStrikethrough":true};
     [result addAttributes:attributes range:NSMakeRange(0, result.length)];
     return [result copy];
 }

--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
@@ -15,7 +15,7 @@
     }
     
     NSMutableAttributedString *result = [attrString mutableCopy];
-    NSDictionary *attributes = @{@"TextAttributeStrikethrough":@""};
+    NSDictionary *attributes = @{@"TextAttributeStrikethrough":@true};
     [result addAttributes:attributes range:NSMakeRange(0, result.length)];
     return [result copy];
 }

--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlSTagTransform.m
@@ -15,7 +15,7 @@
     }
     
     NSMutableAttributedString *result = [attrString mutableCopy];
-    NSDictionary *attributes = @{@"TextAttributeStrikethrough":true};
+    NSDictionary *attributes = @{@"TextAttributeStrikethrough":@true};
     [result addAttributes:attributes range:NSMakeRange(0, result.length)];
     return [result copy];
 }

--- a/VGHtmlParser/Classes/Public/VGHtmlParser.m
+++ b/VGHtmlParser/Classes/Public/VGHtmlParser.m
@@ -14,6 +14,7 @@
 #import "HtmlITagTransform.h"
 #import "HtmlBTagTransform.h"
 #import "HtmlLiTagTransform.h"
+#import "HtmlSTagTransform.h"
 
 
 NSString * const VGHtmlParserMissingTagNameException = @"VGHtmlParserMissingTagNameException";
@@ -36,6 +37,7 @@ NSString * const VGHtmlParserMissingTagNameException = @"VGHtmlParserMissingTagN
     [htmlParser addHtmlTagTransform:[[HtmlITagTransform alloc] init]];
     [htmlParser addHtmlTagTransform:[[HtmlBTagTransform alloc] init]];
     [htmlParser addHtmlTagTransform:[[HtmlLiTagTransform alloc] init]];
+    [htmlParser addHtmlTagTransform:[[HtmlSTagTransform alloc] init]];
     return htmlParser;
 }
 


### PR DESCRIPTION
Add `TextAttributeStrikethrough` attribute to [`s` html tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).

I've decided to add this attribute as it's used in Vinted app for strikethrough styling.
Still currently all attributes are stripped of when `AttributedText` is created and added manually later, so naming doesn't really matter, but if that would change in the future it should just apply the style based on the attribute.

[Jira](https://vinted.atlassian.net/browse/KK-2872)

End result:

<img src="https://github.com/vinted/VGHtmlParser/assets/6301413/a9c99172-0c28-48ec-9c5a-f72bac1f3980" width="300px" />