### PR TITLE
Added TextAttributeHeadIndentEnabled attribute to <li> elements

### DIFF
--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlLiTagTransform.m
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlLiTagTransform.m
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 #import "HtmlLiTagTransform.h"
+#import "VGHtmlParser.h"
 
 @implementation HtmlLiTagTransform
 
@@ -14,7 +15,7 @@
         return attrString;
     }
     
-    NSMutableAttributedString *newAttrString = [[NSMutableAttributedString alloc] initWithString:@"  \u2022  "];
+    NSMutableAttributedString *newAttrString = [[NSMutableAttributedString alloc] initWithString:listBulletSymbol];
     [newAttrString appendAttributedString:[attrString mutableCopy]];
     [newAttrString appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
     

--- a/VGHtmlParser/Classes/Private/VintedTransformers/HtmlLiTagTransform.m
+++ b/VGHtmlParser/Classes/Private/VintedTransformers/HtmlLiTagTransform.m
@@ -17,6 +17,10 @@
     NSMutableAttributedString *newAttrString = [[NSMutableAttributedString alloc] initWithString:@"  \u2022  "];
     [newAttrString appendAttributedString:[attrString mutableCopy]];
     [newAttrString appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
+    
+    NSDictionary *attributes = @{@"TextAttributeHeadIndentEnabled":@true};
+    [newAttrString addAttributes:attributes range:NSMakeRange(0, newAttrString.length)];
+
     return [newAttrString copy];
 }
 

--- a/VGHtmlParser/Classes/Public/VGHtmlParser.h
+++ b/VGHtmlParser/Classes/Public/VGHtmlParser.h
@@ -3,6 +3,7 @@
 
 extern NSString * _Nonnull const VintedLinkAttributeName;
 extern NSString * __nonnull const VGHtmlParserMissingTagNameException;
+extern NSString * _Nonnull const listBulletSymbol;
 
 @interface VGHtmlParser : NSObject
 

--- a/VGHtmlParser/Classes/Public/VGHtmlParser.m
+++ b/VGHtmlParser/Classes/Public/VGHtmlParser.m
@@ -18,6 +18,7 @@
 
 
 NSString * const VGHtmlParserMissingTagNameException = @"VGHtmlParserMissingTagNameException";
+NSString * const listBulletSymbol = @"  \u2022  ";
 
 @interface VGHtmlParser ()
 


### PR DESCRIPTION
This PR adds `TextAttributeHeadIndentEnabled` attribute to `<li>` html tag and a public `listBulletSymbol` const.

The attribute is later used in ios-bloom `AttributedText` to apply list style. Specifically, add headIndent to `<li>` elements. 
